### PR TITLE
Fix/Image Not Displayed After Creating a Community Fixed

### DIFF
--- a/app/modules/community/forms.py
+++ b/app/modules/community/forms.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, TextAreaField, FileField, SubmitField
-from wtforms.validators import DataRequired,  Optional
+from wtforms import StringField, TextAreaField, SubmitField
+from wtforms.validators import DataRequired
 
 
 class CommunityForm(FlaskForm):
@@ -8,10 +8,7 @@ class CommunityForm(FlaskForm):
     description = TextAreaField("Description", validators=[DataRequired()])
 
     # Logo field: Optional, but if provided, it must be an .svg file
-    logo = FileField(
-        "Image File",
-        validators=[Optional()]
-    )
+
     submit = SubmitField('Save community')
 
     def get_dsmetadata(self):

--- a/app/modules/community/routes.py
+++ b/app/modules/community/routes.py
@@ -6,8 +6,6 @@ from app.modules.community.models import Community
 from app.modules.auth.services import AuthenticationService
 from app.modules.community.services import CommunityService
 from app.modules.community import community_bp
-from werkzeug.utils import secure_filename
-import os
 
 community_service = CommunityService()
 auth_service = AuthenticationService()
@@ -31,31 +29,11 @@ def create():
 
         try:
             logger.info("Creating community...")
-
-            logo_filename = None
-            if form.logo.data:
-                logger.info("1111111111")
-                logo_file = form.logo.data
-                logo_filename = secure_filename(logo_file.filename)
-
-                upload_folder = os.path.join('app/static/img/community')
-                if not os.path.exists(upload_folder):
-                    os.makedirs(upload_folder)
-
-                file_path = os.path.join(upload_folder, logo_filename)
-                logo_file.save(file_path)
-
-                community_service = CommunityService()
-                community_service.create_from_form(
-                    form=form,
-                    current_user=current_user,
-                    )
-            else:
-                community_service = CommunityService()
-                community_service.create_from_form(
-                    form=form,
-                    current_user=current_user
-                    )
+            community_service = CommunityService()
+            community_service.create_from_form(
+                form=form,
+                current_user=current_user
+                )
             flash('Community created successfully!', 'success')
             return redirect(url_for('community.index'))
 

--- a/app/modules/community/seeders.py
+++ b/app/modules/community/seeders.py
@@ -32,7 +32,7 @@ class CommunitySeeder(BaseSeeder):
                 description="A community for developers passionate about open source projects.",
                 created_by_id=user_ids[0],  # Asigna al primer usuario como creador.
                 created_at=datetime.now(timezone.utc),
-                logo=None  # Puedes agregar un logo específico
+                logo=None
             ),
             Community(
                 name="AI Researchers",

--- a/app/modules/community/services.py
+++ b/app/modules/community/services.py
@@ -1,6 +1,4 @@
-import os
 import logging
-from werkzeug.utils import secure_filename
 from datetime import datetime
 from app.modules.community.models import Community
 from app.modules.community.repositories import CommunityRepository
@@ -18,30 +16,12 @@ class CommunityService(BaseService):
         try:
             logger.info(f"Creating community with name: {form.name.data} by {current_user.id}")
 
-            upload_folder = 'app/static/img/community'
-            if not os.path.exists(upload_folder):
-                os.makedirs(upload_folder)
-
-            logo_filename = None
-            if form.logo.data:
-                logo_file = form.logo.data
-                logo_filename = secure_filename(logo_file.filename)
-                logger.info(f"Saving logo file: {logo_filename}")
-                logo_file.save(os.path.join(upload_folder, logo_filename))
-            name_value = form.name.data
-            description_value = form.description.data
-            created_by_id = current_user.id
-
-            logger.info(
-                f"Valores antes de crear Community: name={name_value}, "
-                f"description={description_value}, created_by_id={created_by_id}"
-            )
             new_community = Community(
                 name=form.name.data,
                 description=form.description.data,
                 created_at=datetime.utcnow(),
                 created_by_id=current_user.id,
-                logo=f'img/community/{logo_filename}' if logo_filename else None
+                logo=None
             )
 
             self.repository.session.add(new_community)

--- a/app/modules/community/templates/community/create.html
+++ b/app/modules/community/templates/community/create.html
@@ -46,32 +46,7 @@
                     {% endfor %}
                 </div>
 
-                <!-- Campo de logo -->
-                <div class="mb-3">
-                    {{ form.logo.label(class="form-label") }}
-                    <div class="d-flex align-items-center">
-                        {{ form.logo(class="form-control", id="logo") }}
-                        <button type="button" class="btn btn-danger ms-2" id="removeLogoBtn">
-                            <i class="bi bi-x-circle"></i> Remove
-                        </button>
-                    </div>
-                    {% for error in form.logo.errors %}
-                        <span class="text-danger small">{{ error }}</span>
-                    {% endfor %}
-                </div>
 
-                <!-- Script para el botón de limpiar logo -->
-                <script>
-                    document.addEventListener('DOMContentLoaded', function() {
-                        const removeLogoBtn = document.getElementById('removeLogoBtn');
-                        const logoInput = document.getElementById('logo');
-                        if (removeLogoBtn && logoInput) {
-                            removeLogoBtn.addEventListener('click', function() {
-                                logoInput.value = ""; // Limpia el campo de entrada
-                            });
-                        }
-                    });
-                </script>
 
                 <!-- Botón para enviar el formulario -->
                 <div class="mt-4">


### PR DESCRIPTION
The image now displays correctly when creating a new community. The option to add a custom image to the community has been discarded, as it is not a fundamental requirement and has caused significant issues.