### PR TITLE
Fix/Error When Accessing a Community fixed

### DIFF
--- a/app/modules/community/routes.py
+++ b/app/modules/community/routes.py
@@ -44,7 +44,7 @@ def create():
     return render_template('community/create.html', form=form)
 
 
-@community_bp.route('/community/<int:id>', methods=['GET'])
+@community_bp.route('/community/<int:community_id>', methods=['GET'])
 def show_community(community_id):
     community = community_service.get_by_id(community_id)
 
@@ -58,7 +58,7 @@ def show_community(community_id):
     return render_template('community/show.html', community=community, user_fullname=user_fullname)
 
 
-@community_bp.route('/community/<int:id>/delete', methods=['POST'])
+@community_bp.route('/community/<int:community_id>/delete', methods=['POST'])
 @login_required
 def delete_community(community_id):
     community = community_service.get_by_id(community_id)

--- a/app/modules/community/templates/community/index.html
+++ b/app/modules/community/templates/community/index.html
@@ -12,11 +12,11 @@
         {% for community in communities %}
         <div class="col">
             <!-- Envolver todo el div con un enlace para hacerlo clicable -->
-            <a href="{{ url_for('community.show_community', id=community.id) }}" class="text-decoration-none">
+            <a href="{{ url_for('community.show_community', community_id=community.id) }}" class="text-decoration-none">
                 <div class="card h-100">
                     <!-- Renderiza el logo dinámico o el predeterminado -->
                     <img src="{{ url_for('static', filename=community.logo) }}" 
-                         class="card-img-top custom-img" alt="{{ community.name }}">
+                        class="card-img-top custom-img" alt="{{ community.name }}">
                     <div class="card-body custom-card-body">
                         <h5 class="card-title">{{ community.name }}</h5>
                         <p class="card-text">

--- a/app/modules/community/templates/community/show.html
+++ b/app/modules/community/templates/community/show.html
@@ -30,7 +30,7 @@
     <a href="{{ url_for('community.index') }}" class="btn btn-primary">Back to Communities</a>
 
     {% if community.created_by_id == current_user.id %}
-    <form action="{{ url_for('community.delete_community', id=community.id) }}" method="POST" style="display:inline;">
+    <form action="{{ url_for('community.delete_community', community_id=community.id) }}" method="POST" style="display:inline;">
         <button type="submit" class="btn btn-danger">Delete Community</button>
     </form>
     {% endif %}


### PR DESCRIPTION
The issue arose because the parameter in the route was <int:id>, but in the show_community function, the parameter used was community_id, creating an inconsistency that caused errors when trying to access a specific community. To resolve this, the parameter in the route was changed to <int:community_id>, and the function parameter was updated to match.

Additionally, upon reviewing the code, it was discovered that the same issue occurred in the function for deleting communities (delete). A generic id parameter was used in the route, while the function expected community_id. However, this issue was not visible until trying to access a community through show_community, as the community needed to exist before it could be deleted.