### PR TITLE
Fix/Navigation buttons redirect incorrectly to 'communities'  fixed

### DIFF
--- a/app/modules/community/routes.py
+++ b/app/modules/community/routes.py
@@ -42,7 +42,7 @@ def create():
                 current_user=current_user
                 )
             flash('Community created successfully!', 'success')
-            return redirect(url_for('community.index'))
+            return redirect(url_for('community.index_my_communities'))
 
         except Exception as e:
             flash(f'An error occurred: {str(e)}', 'danger')
@@ -85,4 +85,4 @@ def delete_community(community_id):
     except Exception as e:
         flash(f'Error deleting community: {e}', 'danger')
 
-    return redirect(url_for('community.index'))
+    return redirect(url_for('community.index_my_communities'))

--- a/app/modules/community/templates/community/show.html
+++ b/app/modules/community/templates/community/show.html
@@ -20,8 +20,6 @@
     <p><strong>Created At:</strong> {{ community.created_at.strftime('%Y-%m-%d %H:%M:%S') }}</p>
     <p><strong>Created By:</strong> {{ user_fullname }}</p>
 
-    <a href="{{ url_for('community.index') }}" class="btn btn-primary">Back to Communities</a>
-
     {% if community.created_by_id == current_user.id %}
     <form action="{{ url_for('community.delete_community', community_id=community.id) }}" method="POST" style="display:inline;">
         <button type="submit" class="btn btn-danger">Delete Community</button>


### PR DESCRIPTION
Back button removed:

    The "Back" button that previously redirected to "My Communities" or "Communities" has been removed to simplify the interface.

Automatic redirection:

    After creating or deleting a community, the user is now automatically redirected to "My Communities".